### PR TITLE
Install the latest StorPool version available.

### DIFF
--- a/reactive/storpool_openstack_integration.py
+++ b/reactive/storpool_openstack_integration.py
@@ -121,8 +121,8 @@ def install_package():
 
     spstatus.npset('maintenance', 'installing the StorPool OpenStack packages')
     (err, newly_installed) = sprepo.install_packages({
-        'storpool-block': spver,
-        'python-storpool-spopenstack': spver,
+        'storpool-block': '*',
+        'python-storpool-spopenstack': '*',
         'storpool-openstack-integration': sposiver,
     })
     if err is not None:


### PR DESCRIPTION
Ignore the storpool_version charm configuration variable; StorPool will
take care of keeping compatible versions in our PPA.

This allows automated upgrades with no operator involvement.